### PR TITLE
Fixed FM and VHF for Raspbian Strech

### DIFF
--- a/src/rtlsdr_pi.h
+++ b/src/rtlsdr_pi.h
@@ -29,7 +29,7 @@
 
 #include <wx/wx.h>
 #include <wx/fileconf.h>
-
+#include <future>
 #include "version.h"
 
 #define     MY_API_VERSION_MAJOR    1
@@ -67,6 +67,8 @@ public:
       wxString GetCommonName();
       wxString GetShortDescription();
       wxString GetLongDescription();
+
+      std::future<void> thread_pipe;
 
       int GetToolbarToolCount(void);
 


### PR DESCRIPTION
I added a background thread in order to pipe the output of the rtl_fm command to aplay. I also changed from 48K to 48 in the aplay command. It was giving me an error. For me the plugin is working now flawlessly. I share the code if someone needs it.